### PR TITLE
Add strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Trie = require('./src/trie');
 
 /**


### PR DESCRIPTION
under node v4:

> SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode