### PR TITLE
Correctly sort nested alternations

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -17,6 +17,10 @@ class Alternation {
     ), []);
   }
 
+  get length() {
+    return this.options[0].length;
+  }
+
   toString() {
     return this.options.map(o => parens(o, this)).join('|');
   }

--- a/test/test.js
+++ b/test/test.js
@@ -84,4 +84,12 @@ describe('regexgen', function () {
 
     assert.deepEqual(s.match(r)[0], s);
   });
+
+  it('should sort alternations of alternations correctly', function () {
+    let r = regexgen(['aef', 'aghz', 'ayz', 'abcdz', 'abcd']);
+    let s = 'abcdz';
+
+    assert.deepEqual(s.match(r)[0], s);
+    assert.deepEqual(r, /a(?:(?:bcd|gh|y)z|bcd|ef)/);
+  });
 });


### PR DESCRIPTION
This is an extension of the fix for #10, where a `length` getter had been added for all AST classes except `Alternation`. This meant that alternations that contained other alternations ended up with `NaN` values in the sorting function.
I used the `length` of the first option in an alternation as the alternation's length, since the options are already sorted by length (so the first one must be the longest).

I also provided the smallest accurate test case I could find. Without the `length` getter, the generated regex is `/a(?:bcd|(?:bcd|gh|y)z|ef)/`, which means that testing `"abcdz"` (one of the inputs) matches only `"abcd"`. This is what was causing some of the failures in mathiasbynens/emoji-regex#16.