### PR TITLE
Allow output of ES2015-style Unicode regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,30 @@ t.toRegExp(); // => /fooba[rz]/
 
 `regexgen` also has a simple CLI to generate regexes using inputs from the command line.
 
-```
+```shell
 $ regexgen
 Usage: regexgen [-gimuy] string1 string2 string3...
 ```
 
 The optional first parameter is the [flags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) to add
 to the regex (e.g. `-i` for a case insensitive match).
+
+## ES6 and Unicode
+
+By default `regexgen` will output a standard JavaScript regular expression, with Unicode codepoints converted into UCS-2 surrogate pairs.
+
+If desired, you can request an ES6-style Unicode regular expression by supplying the `-u` flag, which results in those codepoints being retained.
+
+```shell
+$ regexgen 👩 👩‍💻 👩🏻‍💻 👩🏼‍💻 👩🏽‍💻 👩🏾‍💻 👩🏿‍💻
+/\uD83D\uDC69(?:(?:\uD83C[\uDFFB-\uDFFF])?\u200D\uD83D\uDCBB)?/
+
+$ regexgen -u 👩 👩‍💻 👩🏻‍💻 👩🏼‍💻 👩🏽‍💻 👩🏾‍💻 👩🏿‍💻
+/\u{1F469}(?:(?:[\u{1F3FB}-\u{1F3FF}])?\u200D\u{1F4BB})?/u
+```
+
+
+Such regular expressions are compatible with current versions of Node, as well as the latest browsers, and may be more transferrable to other languages.
 
 ## How does it work?
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Usage: regexgen [-gimuy] string1 string2 string3...
 The optional first parameter is the [flags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) to add
 to the regex (e.g. `-i` for a case insensitive match).
 
-## ES6 and Unicode
+## ES2015 and Unicode
 
 By default `regexgen` will output a standard JavaScript regular expression, with Unicode codepoints converted into UCS-2 surrogate pairs.
 
-If desired, you can request an ES6-style Unicode regular expression by supplying the `-u` flag, which results in those codepoints being retained.
+If desired, you can request an ES2015-compatible Unicode regular expression by supplying the `-u` flag, which results in those codepoints being retained.
 
 ```shell
 $ regexgen 👩 👩‍💻 👩🏻‍💻 👩🏼‍💻 👩🏽‍💻 👩🏾‍💻 👩🏿‍💻

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const regexgen = require('../');
+const Trie = require('../src/trie');
 
 let args = process.argv.slice(2);
 let flags = '';
@@ -13,4 +13,7 @@ if (args.length === 0) {
   process.exit(1);
 }
 
-console.log(regexgen(args, flags));
+let trie = new Trie;
+trie.addAll(args);
+
+console.log(`/${trie.toString()}/${flags}`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,4 +16,4 @@ if (args.length === 0) {
 let trie = new Trie;
 trie.addAll(args);
 
-console.log(`/${trie.toString()}/${flags}`);
+console.log(new RegExp(trie.toString(), flags));

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const Trie = require('../src/trie');
+const regexgen = require('../');
 
 let args = process.argv.slice(2);
 let flags = '';
@@ -13,7 +13,4 @@ if (args.length === 0) {
   process.exit(1);
 }
 
-let trie = new Trie;
-trie.addAll(args);
-
-console.log(new RegExp(trie.toString(), flags));
+console.log(regexgen(args, flags));

--- a/src/ast.js
+++ b/src/ast.js
@@ -44,7 +44,7 @@ class CharClass {
   }
 
   get isSingleCodepoint() {
-    return Array.from(this.set).length === 1;
+    return true;
   }
 
   toString(flags) {

--- a/src/ast.js
+++ b/src/ast.js
@@ -149,7 +149,7 @@ class Literal {
       .replace(/[\t\n\f\r\$\(\)\*\+\-\.\?\[\]\^\|]/g, '\\$&')
       .replace(
         // special handling to not escape curly braces which are part of Unicode escapes
-        /(\\u\{[a-z1-9]+\})|([\{\}])/ig,
+        /(\\u\{[a-z0-9]+\})|([\{\}])/ig,
         (match, unicode, brace) => unicode || '\\' + brace
       );
   }

--- a/src/ast.js
+++ b/src/ast.js
@@ -30,25 +30,30 @@ class Alternation {
  * Represents a character class (e.g. [0-9a-z])
  */
 class CharClass {
-  constructor(a, b) {
+  constructor(a, b, flags) {
     this.precedence = 1;
     this.set = regenerate(a, b);
+    this.flags = flags;
   }
 
   get length() {
     return 1;
   }
 
+  get isSingleCharacter() {
+    return !this.set.toArray().some(c => c > 0xffff);
+  }
+
+  get isUnicode() {
+    return this.flags && this.flags.indexOf('u') !== -1;
+  }
+
   toString() {
-    return this.set.toString({ hasUnicodeFlag: true });
+    return this.set.toString({ hasUnicodeFlag: this.isUnicode });
   }
 
   getCharClass() {
     return this.set;
-  }
-
-  get isSingleCharacter() {
-    return !this.set.toArray().some(c => c > 0xffff);
   }
 }
 
@@ -117,9 +122,10 @@ class Repetition {
  * Represents a literal (e.g. a string)
  */
 class Literal {
-  constructor(value) {
+  constructor(value, flags) {
     this.precedence = 2;
     this.value = value;
+    this.flags = flags;
   }
 
   get isEmpty() {
@@ -130,12 +136,16 @@ class Literal {
     return this.length === 1;
   }
 
+  get isUnicode() {
+    return this.flags && this.flags.indexOf('u') !== -1;
+  }
+
   get length() {
     return this.value.length;
   }
 
   toString() {
-    return jsesc(this.value, { es6: true });
+    return jsesc(this.value, { es6: this.isUnicode });
   }
 
   getCharClass() {

--- a/src/ast.js
+++ b/src/ast.js
@@ -40,7 +40,7 @@ class CharClass {
   }
 
   toString() {
-    return this.set.toString();
+    return this.set.toString({ hasUnicodeFlag: true });
   }
 
   getCharClass() {
@@ -135,7 +135,7 @@ class Literal {
   }
 
   toString() {
-    return jsesc(this.value).replace(/([\t\n\f\r\$\(\)\*\+\-\.\?\[\]\^\{\|\}])/g, '\\$1');
+    return jsesc(this.value, { es6: true });
   }
 
   getCharClass() {

--- a/src/ast.js
+++ b/src/ast.js
@@ -147,21 +147,11 @@ class Literal {
   toString() {
     return jsesc(this.value, { es6: this.isUnicode })
       .replace(/[\t\n\f\r\$\(\)\*\+\-\.\?\[\]\^\|]/g, '\\$&')
-      .replace(/[\{\}]/g, (match, offset, string) => {
+      .replace(
         // special handling to not escape curly braces which are part of Unicode escapes
-
-        // don't escape opening curly braces immediately preceded by `\u`
-        if (match === '{' && string.slice(offset - 2, offset) === '\\u') {
-          return match;
-        }
-
-        // don't escape closing curly braces ending Unicode escapes
-        if (match === '}' && string.slice(offset - 8, offset - 5) === '\\u{') {
-          return match;
-        }
-
-        return '\\' + match;
-      });
+        /(\\u\{[a-z1-9]+\})|([\{\}])/ig,
+        (match, unicode, brace) => unicode || '\\' + brace
+      );
   }
 
   getCharClass() {

--- a/src/ast.js
+++ b/src/ast.js
@@ -145,7 +145,23 @@ class Literal {
   }
 
   toString() {
-    return jsesc(this.value, { es6: this.isUnicode });
+    return jsesc(this.value, { es6: this.isUnicode })
+      .replace(/[\t\n\f\r\$\(\)\*\+\-\.\?\[\]\^\|]/g, '\\$&')
+      .replace(/[\{\}]/g, (match, offset, string) => {
+        // special handling to not escape curly braces which are part of Unicode escapes
+
+        // don't escape opening curly braces immediately preceded by `\u`
+        if (match === '{' && string.slice(offset - 2, offset) === '\\u') {
+          return match;
+        }
+
+        // don't escape closing curly braces ending Unicode escapes
+        if (match === '}' && string.slice(offset - 8, offset - 5) === '\\u{') {
+          return match;
+        }
+
+        return '\\' + match;
+      });
   }
 
   getCharClass() {

--- a/src/trie.js
+++ b/src/trie.js
@@ -47,10 +47,11 @@ class Trie {
 
   /**
    * Returns a regex pattern that matches the strings in the trie.
+   * @param {string} flags - The flags to add to the regex.
    * @return {string} pattern - The regex pattern.
    */
-  toString() {
-    return toRegex(this.minimize());
+  toString(flags) {
+    return toRegex(this.minimize(), flags);
   }
 
   /**
@@ -59,7 +60,7 @@ class Trie {
    * @return {RegExp}
    */
   toRegExp(flags) {
-    return new RegExp(this.toString(), flags);
+    return new RegExp(this.toString(flags), flags);
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,7 @@ describe('regexgen', function () {
 
   it('should escape meta characters', function () {
     assert.deepEqual(regexgen(['foo|bar[test]+']), /foo\|bar\[test\]\+/);
+    assert.deepEqual(regexgen(['u{}\\iu']), /u\{\}\\iu/);
   });
 
   it('should escape non-ascii characters', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -71,7 +71,7 @@ describe('regexgen', function () {
   });
 
   it('should retain non-BMP codepoints when the Unicode flag is passed', function () {
-    assert.deepEqual(regexgen(['\u261D', '\u261D\u{1f3fb}'], 'u'), /\u261D(?:\u{1F3FB})?/u);
+    assert.deepEqual(regexgen(['\u261D', '\u261D\u{1f3fb}'], 'u'), /\u261D\u{1F3FB}?/u);
   });
 
   it('should correctly extract common prefix from multiple alternations', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -69,6 +69,10 @@ describe('regexgen', function () {
     assert.deepEqual(regexgen(['\u261D', '\u261D\u{1f3fb}']), /\u261D(?:\uD83C\uDFFB)?/);
   });
 
+  it('should retain non-BMP codepoints when the Unicode flag is passed', function () {
+    assert.deepEqual(regexgen(['\u261D', '\u261D\u{1f3fb}'], 'u'), /\u261D(?:\u{1F3FB})?/u);
+  });
+
   it('should correctly extract common prefix from multiple alternations', function () {
     assert.deepEqual(regexgen(['abjv', 'abxcjv', 'abydjv', 'abzejv']), /ab(?:ze|yd|xc)?jv/);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,33 @@ describe('regexgen', function () {
     assert.deepEqual(s.match(r)[0], s);
   });
 
+  it('should sort non-BMP alternation options correctly', function () {
+    let r = regexgen(
+      [
+        // shrug emoji
+        '\u{1F937}\u200D',
+        // shrug emoji with fitzpatrick modifiers
+        '\u{1F937}\u{1F3FB}\u200D',
+        '\u{1F937}\u{1F3FC}\u200D',
+        '\u{1F937}\u{1F3FD}\u200D',
+        '\u{1F937}\u{1F3FE}\u200D',
+        '\u{1F937}\u{1F3FF}\u200D',
+        // shrug emoji with gender modifier
+        '\u{1F937}\u200D\u2640\uFE0F',
+        // shrug emoji with gender and fitzpatrick modifiers
+        '\u{1F937}\u{1F3FB}\u200D\u2640\uFE0F',
+        '\u{1F937}\u{1F3FC}\u200D\u2640\uFE0F',
+        '\u{1F937}\u{1F3FD}\u200D\u2640\uFE0F',
+        '\u{1F937}\u{1F3FE}\u200D\u2640\uFE0F',
+        '\u{1F937}\u{1F3FF}\u200D\u2640\uFE0F'
+      ],
+      'u'
+    );
+
+    assert.deepEqual(r, /\u{1F937}[\u{1F3FB}-\u{1F3FF}]?\u200D(?:\u2640\uFE0F)?/u);
+    assert.deepEqual('\u{1F937}\u{1F3FB}\u200D\u2640\uFE0F'.match(r)[0], '\u{1F937}\u{1F3FB}\u200D\u2640\uFE0F');
+  });
+
   it('should sort alternations of alternations correctly', function () {
     let r = regexgen(['aef', 'aghz', 'ayz', 'abcdz', 'abcd']);
     let s = 'abcdz';

--- a/test/test.js
+++ b/test/test.js
@@ -78,6 +78,13 @@ describe('regexgen', function () {
     );
   });
 
+  it('should handle non-BMP codepoint ranges correctly', function() {
+    assert.deepEqual(
+      regexgen(['\u{1F311}', '\u{1F312}', '\u{1F313}', '\u{1F314}', '\u{1F315}', '\u{1F316}', '\u{1F317}', '\u{1F318}'], 'u'),
+      /[\u{1F311}-\u{1F318}]/u
+    );
+  });
+
   it('should correctly extract common prefix from multiple alternations', function () {
     assert.deepEqual(regexgen(['abjv', 'abxcjv', 'abydjv', 'abzejv']), /ab(?:ze|yd|xc)?jv/);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,10 @@ describe('regexgen', function () {
 
   it('should retain non-BMP codepoints when the Unicode flag is passed', function () {
     assert.deepEqual(regexgen(['\u261D', '\u261D\u{1f3fb}'], 'u'), /\u261D\u{1F3FB}?/u);
+    assert.deepEqual(
+      regexgen(['\u{1F3F4}', '\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}', '\u{1F3F4}\u{E0067}\u{E0062}\u{E0077}\u{E006C}\u{E0073}', '\u{1F3F4}\u{E0067}\u{E0062}\u{E0073}\u{E0063}\u{E0074}'], 'u'),
+      /\u{1F3F4}(?:\u{E0067}\u{E0062}(?:\u{E0073}\u{E0063}\u{E0074}|\u{E0077}\u{E006C}\u{E0073}|\u{E0065}\u{E006E}\u{E0067}))?/u
+    );
   });
 
   it('should correctly extract common prefix from multiple alternations', function () {


### PR DESCRIPTION
This is a polished up version of what I was working on as part of #15; it updates regexgen to optionally output ES6-compatible Unicode regexes.

It does this by looking at the flags passed; if `u` is included, it outputs a Unicode regex rather than an UCS-2 style regex, by passing the requisite options down to `regenerate` and `jsesc`.

~This isn’t the _cleanest_ change, as no state was previously passed down into the AST methods, so it required quite a bit of passing around. I also only added the additional arguments to the AST object classes affected by the change!~ State is no longer passed down into AST constructors as of 7b560c7, instead being passed to `toString` methods to control their behaviour directly!

fixes #15

Todo:
- [x] Clean up for PR
- [x] Write specs for the updated behaviour
- [x] Document updated behaviour